### PR TITLE
added functionality for skipping lines at footer

### DIFF
--- a/sfhutils.py
+++ b/sfhutils.py
@@ -8,7 +8,7 @@ pc2cm = 3.086e18
 magsphere = 4.*np.pi*100*pc2cm**2
 skiprows = 0 #number of extra rows at the top of the SFH files
 
-def load_angst_sfh(name, sfhdir = '', skiprows = 0, fix_youngest = False):
+def load_angst_sfh(name, sfhdir = '', skiprows = 0, fix_youngest = False, bg_flag=False, skip_footer=2):
     """
     Read a `match`-produced, zcombined SFH file into a numpy
     structured array.
@@ -28,7 +28,10 @@ def load_angst_sfh(name, sfhdir = '', skiprows = 0, fix_youngest = False):
     dt = np.dtype([('t1', ty), ('t2',ty), ('dmod',ty), ('sfr',ty), ('met', ty), ('mformed',ty)])
     #fn = glob.glob("{0}*{1}*sfh".format(sfhdir,name))[0]
     fn = name
-    data = np.loadtxt(fn, usecols = (0,1,2,3,6,12) ,dtype = dt, skiprows = skiprows)
+    if bg_flag:
+        data = np.genfromtxt(fn, usecols=(0,1,2,3,6,12) , dtype=dt, skiprows=skiprows, skip_footer=skip_footer)
+    else:
+        data = np.loadtxt(fn, usecols = (0,1,2,3,6,12) ,dtype = dt, skiprows = skiprows)
     if fix_youngest:
         pass
     return data


### PR DESCRIPTION
My zcombine outputs have two lines at the bottom of the file associated with the background, so I have changed load_angst_sfh to be able to read files with this format. Unfortunately loadtxt doesn't have the ability to skip arbitrary lines or lines at the bottom of files, so I used genfromtxt. Genfromtxt is supposedly slower, but I did a timeit test reading 10k files - it took 10.2 seconds for loadtxt vs 11.4s for genfromtxt, so they are at least order of magnitude similar.
